### PR TITLE
chore: 6.9.1-1deepin2: Backport (man/man2/mkdir.2: add missing .TP)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+manpages (6.9.1-1deepin2) unstable; urgency=medium
+
+  * Add new patch 0018-man-man2-mkdir.2-add-missing.TP.patch
+    - Link: https://lore.kernel.org/linux-man/acnm342pailsiqqrelvaugpaupuceks5hvtvapejydxkig627b@acdnbxarcmro/T/#m2c7b3fc1c98ff3da9a7b6cbfb7f57916148bd87b
+    - Reason: It is authored by Chen Linxuan <chenlinxuan@uniontech.com>
+
+ -- WangYuli <wangyuli@uniontech.com>  Mon, 3 Mar 2025 18:18:55 +0800
+
 manpages (6.9.1-1deepin1) unstable; urgency=medium
 
   * Add new patch 0017-man-man2-mkdir.2-ERRORS-Add-EOVERFLOW.patch

--- a/debian/patches/0018-man-man2-mkdir.2-add-missing.TP.patch
+++ b/debian/patches/0018-man-man2-mkdir.2-add-missing.TP.patch
@@ -1,0 +1,27 @@
+From f96a882532f67b516afa89b6e8feb6064c4e344a Mon Sep 17 00:00:00 2001
+From: Chen Linxuan <chenlinxuan@uniontech.com>
+Date: Mon, 3 Mar 2025 17:50:57 +0800
+Subject: man/man2/mkdir.2: ffix
+
+Fixes: 2904e040ded2 (2025-02-02; "man/man2/mkdir.2: ERRORS: Add EOVERFLOW")
+Signed-off-by: Chen Linxuan <chenlinxuan@uniontech.com>
+Message-ID: <6DF9A4EE0A868FB4+20250303095057.92138-1-chenlinxuan@uniontech.com>
+Signed-off-by: Alejandro Colomar <alx@kernel.org>
+---
+ man/man2/mkdir.2 | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/man/man2/mkdir.2 b/man/man2/mkdir.2
+index 3c3fad6ee..20163c88e 100644
+--- a/man/man2/mkdir.2
++++ b/man/man2/mkdir.2
+@@ -203,6 +203,7 @@ does not support the creation of directories.
+ .B EROFS
+ .I pathname
+ refers to a file on a read-only filesystem.
++.TP
+ .B EOVERFLOW
+ UID or GID mappings (see
+ .BR user_namespaces (7))
+-- 
+cgit v1.2.3

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@
 0015-fix-groff-warning.patch
 0016-set-fhs-mansections.patch
 0017-man-man2-mkdir.2-ERRORS-Add-EOVERFLOW.patch
+0018-man-man2-mkdir.2-add-missing.TP.patch


### PR DESCRIPTION
This commit is authored by Uniontech, backport it.

[ Origin commit message: ]
Fixes: 2904e040ded2 (2025-02-02; "man/man2/mkdir.2: ERRORS: Add EOVERFLOW")

Message-ID: <6DF9A4EE0A868FB4+20250303095057.92138-1-chenlinxuan@uniontech.com>


Link: https://lore.kernel.org/linux-man/acnm342pailsiqqrelvaugpaupuceks5hvtvapejydxkig627b@acdnbxarcmro/T/#mce669bcd81009c761de8c24b2cb8286c04e7e662
Link: https://www.alejandro-colomar.es/src/alx/linux/man-pages/man-pages.git/commit/?h=contrib&id=f96a882532f67b516afa89b6e8feb6064c4e344a